### PR TITLE
add deployment action for rumprun demo apps

### DIFF
--- a/.github/workflows/rump-deploy.yml
+++ b/.github/workflows/rump-deploy.yml
@@ -1,0 +1,98 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Deploy default.xml to rumprun-sel4-demoapps after successful runs.
+
+name: RumpRun
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - 'default.xml' # avoid loop when deploying to default.xml
+
+  # allow manual trigger
+  workflow_dispatch:
+
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
+
+jobs:
+  code:
+    name: Freeze Code
+    runs-on: ubuntu-latest
+    outputs:
+      xml: ${{ steps.repo.outputs.xml }}
+    steps:
+    - id: repo
+      uses: seL4/ci-actions/repo-checkout@master
+      with:
+        manifest_repo: rumprun-sel4-demoapps
+        manifest: master.xml
+
+  build:
+    name: Hello World Build
+    runs-on: ubuntu-latest
+    needs: code
+    strategy:
+      fail-fast: false
+      matrix:
+        req: [sim, haswell3]
+    steps:
+    - name: Build
+      uses: seL4/ci-actions/rump-hello@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        req: ${{ matrix.req }}
+    - name: Upload images
+      if: ${{ matrix.req != 'sim' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: images-${{ matrix.req }}
+        path: '*-images.tar.gz'
+
+  hw-run:
+    name: Hello World Hardware Run
+    if: ${{ github.repository_owner == 'seL4' }}
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        req: [haswell3]
+    # do not run concurrently with other workflows, but do run concurrently in the build matrix
+    concurrency: rumprun-hw-${{ strategy.job-index }}
+    steps:
+      - name: Get machine queue
+        uses: actions/checkout@v2
+        with:
+          repository: seL4/machine_queue
+          path: machine_queue
+          token: ${{ secrets.PRIV_REPO_TOKEN }}
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: images-${{ matrix.req }}
+      - name: Run
+        uses: seL4/ci-actions/rump-hello-hw@master
+        with:
+          req: ${{ matrix.req }}
+          index: $${{ strategy.job-index }}
+        env:
+          HW_SSH: ${{ secrets.HW_SSH }}
+
+  deploy:
+    name: Deploy manifest
+    if: ${{ github.repository_owner == 'seL4' }}
+    runs-on: ubuntu-latest
+    needs: [code, hw-run]
+    steps:
+    - name: Deploy
+      uses: seL4/ci-actions/manifest-deploy@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        manifest_repo: rumprun-sel4-demoapps
+      env:
+        GH_SSH: ${{ secrets.CI_SSH }}

--- a/.github/workflows/rump-deploy.yml
+++ b/.github/workflows/rump-deploy.yml
@@ -4,7 +4,7 @@
 
 # Deploy default.xml to rumprun-sel4-demoapps after successful runs.
 
-name: RumpRun
+name: Hello World
 
 on:
   push:
@@ -33,7 +33,7 @@ jobs:
         manifest: master.xml
 
   build:
-    name: Hello World Build
+    name: Build
     runs-on: ubuntu-latest
     needs: code
     strategy:
@@ -54,7 +54,7 @@ jobs:
         path: '*-images.tar.gz'
 
   hw-run:
-    name: Hello World Hardware Run
+    name: Hardware Run
     if: ${{ github.repository_owner == 'seL4' }}
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,14 @@
 
 # Actions to run on pull requests
 
-name: RumpRun PR
+name: Hello World (PR)
 
 on:
   pull_request:
 
 jobs:
   hello:
-    name: Hello World
+    name: Test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,9 @@
 
 # Actions to run on pull requests
 
-name: RumpRun
+name: RumpRun PR
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 # Rumprun apps
 
+[![CI](https://github.com/seL4/rumprun-sel4-demoapps/actions/workflows/push.yml/badge.svg)](https://github.com/seL4/rumprun-sel4-demoapps/actions/workflows/push.yml)
+[![Hello World](https://github.com/seL4/rumprun-sel4-demoapps/actions/workflows/rump-deploy.yml/badge.svg)](https://github.com/seL4/rumprun-sel4-demoapps/actions/workflows/rump-deploy.yml)
+
 This repository contains several apps for running with the rumprun unikernel with seL4 as the target platform.  It also conatins a seL4 root-task that creates and initialises a rumprun instance as a separate process.
 Rumprun images are generally constructed by building the rumprun sources, compiling an app with the rumprun
 toolchains, baking the app using `rumprun-bake` which links in the rumprun and rumpkernel libraries, and finally


### PR DESCRIPTION
This still only tests the hello-world app (as did Bamboo), but now the manifest is updated on successful completion, and it will trigger when any dependency is updated.

Corresponds to seL4/ci-actions#169