### PR TITLE
github: bump GitHub action versions

### DIFF
--- a/.github/workflows/rump-deploy.yml
+++ b/.github/workflows/rump-deploy.yml
@@ -48,7 +48,7 @@ jobs:
         req: ${{ matrix.req }}
     - name: Upload images
       if: ${{ matrix.req != 'sim' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: images-${{ matrix.req }}
         path: '*-images.tar.gz'
@@ -66,13 +66,13 @@ jobs:
     concurrency: rumprun-hw-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: seL4/machine_queue
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: images-${{ matrix.req }}
       - name: Run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         req: ${{ matrix.req }}
     - name: Upload images
       if: ${{ matrix.req != 'sim' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: images-${{ matrix.req }}
         path: '*-images.tar.gz'


### PR DESCRIPTION
Update to current node16 versions. The old node12 actions are deprecated and will stop working.