### PR TITLE
github: pin Ubuntu 22.04 for deployment step

### DIFF
--- a/.github/workflows/rump-deploy.yml
+++ b/.github/workflows/rump-deploy.yml
@@ -86,7 +86,7 @@ jobs:
   deploy:
     name: Deploy manifest
     if: ${{ github.repository_owner == 'seL4' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [code, hw-run]
     steps:
     - name: Deploy


### PR DESCRIPTION
Python 3.12 in Ubuntu 24.04 has incompatible packages.