### PR TITLE
workflows: use ${{ variable }} not invalid $${{

### DIFF
--- a/.github/workflows/rump-deploy.yml
+++ b/.github/workflows/rump-deploy.yml
@@ -79,7 +79,7 @@ jobs:
         uses: seL4/ci-actions/rump-hello-hw@master
         with:
           req: ${{ matrix.req }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
 


### PR DESCRIPTION
I'm not entirely sure how this worked... but I guess GitHub ignores the extra $ sign.